### PR TITLE
fix: link to medium article

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## 📑 Artigo
 
-[Testes unitários com Next JS, React Hook Form, Jest e Testing Library](https://medium.com/@lspeixotodev/fluxo-de-dados-via-rota-no-angular-58631d598ce5)
+[Testes unitários com Next JS, React Hook Form, Jest e Testing Library](https://medium.com/@lspeixotodev/testes-unitários-com-next-js-react-hook-form-jest-e-testing-library-a8081afa8103)
 
 ## 💻 Repositório
 


### PR DESCRIPTION
The link to the medium article related to the repo was pointing to an article about routes in angular, this pr changes the link src so it points to the correct article